### PR TITLE
Address Deprecations and obsolete usages, use git-based versioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,17 +3,30 @@ name: main
 on:
   push:
     branches: [$default-branch]
-  pull_request: {}
+  pull_request:
 
 jobs:
   main:
+    name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
-      - run: pip install poetry==1.1.11
-      - run: poetry install
-      - run: poetry run black --check .
-      - run: poetry run pytest tests/test_metalink4.py 
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        run: |
+          python -m pip install poetry==1.8.3
+      - name: Install pymetalink
+        run: |
+          python -m poetry install
+      - name: Run linting
+        if: matrix.python-version == '3.8'
+        run: |
+          python -m poetry run black --check .
+      - name: Run tests
+        run: |
+          python -m poetry run pytest tests/test_metalink4.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,21 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
-      - run: pip install poetry==1.1.11
-      - run: poetry install
-      - name: Build and publish
+      - run: pip install poetry==1.9.0
+      - run: |
+          poetry install
+      - name: Build and Publish
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          # These should be replaced by a token with upload access to PyPI
+          # POETRY_PYPI_TOKEN_PYPI={{ SOME_TOKEN }}
+          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          poetry version ${{ github.event.release.tag_name }}
+          poetry self add poetry-version-plugin
           poetry build
-          poetry run twine upload dist/*
+          poetry publish

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pytest_cache
 /dist
 __pycache__
+.idea
 .mypy_cache
 .venv
 .vscode

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,3 +2,6 @@ Neil McNab <webmaster@nabber.org>
 Hampus Wessman
 Andrew Kuchling
 Richard Jones
+Bram Nejit
+Carsten Ehbrecht
+Trevor James Smith

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Neil McNab, Hampus Wessman
+Copyright (c) 2007-2016 Neil McNab and Hampus Wessman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy 
 of this software and associated documentation files (the "Software"), to deal 

--- a/metalink/GPG.py
+++ b/metalink/GPG.py
@@ -41,11 +41,7 @@ We are not using it, but the most current code appears to be at: https://pythonh
 __rcsid__ = "$Id: GPG.py,v 1.3 2003/11/23 15:03:15 akuchling Exp $"
 
 import sys
-
-if sys.version_info < (3,):
-    import StringIO
-else:
-    import io as StringIO
+import io as StringIO
 
 import base64
 import gettext
@@ -76,11 +72,10 @@ def translate():
         base = temp[-1]
         localedir = os.path.join("/".join(["%s" % k for k in temp[:-1]]), "locale")
 
-    # print base, localedir, locale.getdefaultlocale()
-    localelang = locale.getdefaultlocale()[0]
-    if localelang == None:
-        localelang = "LC_ALL"
-    t = gettext.translation(base, localedir, [localelang], None, "en")
+    locale_lang = locale.getlocale()[0]
+    if locale_lang is None:
+        locale_lang = "LC_ALL"
+    t = gettext.translation(base, localedir, [locale_lang], None, "en")
     try:
         return t.ugettext
     # python3
@@ -105,9 +100,7 @@ DEFAULT_PATH = [
 
 
 class Signature:
-    """
-    Used to hold information about a signature result
-    """
+    """Used to hold information about a signature result."""
 
     def __init__(self):
         self.valid = 0
@@ -177,20 +170,28 @@ class Signature:
         # raise AssertionError, "File not properly loaded for signature."
 
     def is_valid(self):
-        """
-        returns boolean result of signature valididity
-        """
+        """Returns boolean result of signature validity."""
         return self.valid
 
 
 class ImportResult:
-    """
-    Used to hold information about a key import result
-    """
+    """Used to hold information about a key import result."""
 
-    counts = """count no_user_id imported imported_rsa unchanged
-            n_uids n_subk n_sigs n_revoc sec_read sec_imported
-            sec_dups not_imported""".split()
+    counts = [
+        "count",
+        "imported",
+        "imported_rsa",
+        "n_revoc",
+        "n_sigs",
+        "n_subk",
+        "n_uids",
+        "no_user_id",
+        "not_imported",
+        "sec_dups",
+        "sec_imported",
+        "sec_read",
+        "unchanged",
+    ]
 
     def __init__(self):
         self.imported = []
@@ -462,8 +463,8 @@ class GPGSubprocess:
         """
         Verify the signature on the contents of the string 'data'
         """
-        fileobj = StringIO.StringIO(data)
-        return self.verify_file(fileobj)
+        file_obj = StringIO.StringIO(data)
+        return self.verify_file(file_obj)
 
     def verify_file(self, file):
         """
@@ -574,7 +575,7 @@ def decode(filename):
     """
     Decodes data elements from a given PGP file name.
     """
-    if filename == None:
+    if filename is None:
         return []
     if filename.endswith(".asc"):
         return decode_asc(filename)

--- a/metalink/__init__.py
+++ b/metalink/__init__.py
@@ -1,1 +1,29 @@
+#!/usr/bin/env python
+########################################################################
+#
+# Project: pyMetalink
+# URL: https://github.com/metalink-dev/pymetalink
+# E-mail: nabber00@gmail.com
+#
+# Copyright: (C) 2007-2016 Neil McNab and Hampus Wessman
+# License: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+########################################################################
 from .metalink import *

--- a/metalink/console.py
+++ b/metalink/console.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright: (C) 2016, Neil McNab
+# Copyright: (C) 2007-2016 Neil McNab and Hampus Wessman
 # License: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -55,8 +55,6 @@ class ProgressBar:
         self.show_time = True
         self.show_bytes = True
         self.show_percent = True
-        # print ""
-        # self.update(0, 0)
         self.total_size = 0
 
     def download_update(self, block_count, block_size, total_size):
@@ -82,17 +80,17 @@ class ProgressBar:
 
         bytes = ""
         if self.show_bytes:
-            bytes = " %.2f/%.2f MB" % (current_bytes, total_bytes)
+            bytes = f" {current_bytes:.2f}/{total_bytes:.2f} MB"
 
         bitinfo = ""
-        if self.bitrate != None and self.show_bitrate:
+        if self.bitrate is not None and self.show_bitrate:
             if self.bitrate > 1000:
                 bitinfo = " %.2f Mbps" % (float(self.bitrate) / float(1000))
             else:
                 bitinfo = " %.0f kbps" % self.bitrate
 
         timeinfo = ""
-        if self.time != None and self.time != "" and self.show_time:
+        if self.time is not None and self.time != "" and self.show_time:
             timeinfo += " " + self.time
 
         length = (

--- a/metalink/download.py
+++ b/metalink/download.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 ########################################################################
 #
 # Project: pyMetalink
 # URL: https://github.com/metalink-dev/pymetalink
 # E-mail: nabber00@gmail.com
 #
-# Copyright: (C) 2007-2015, Neil McNab
+# Copyright: (C) 2007-2016 Neil McNab and Hampus Wessman
 # License: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -55,33 +54,20 @@
 ########################################################################
 import sys
 
-if sys.version_info < (3,):
-    import BaseHTTPServer
-    import httplib
-    import urllib2
-    import urlparse
-#    import HTMLParser
-else:
-    import http.client as httplib
-    import http.server as BaseHTTPServer
-    import io
-    import urllib.parse as urlparse
+import http.client as httplib
+import http.server as BaseHTTPServer
+import io
+import urllib.parse as urlparse
 
-    #    import html.parser as HTMLParser
-    import urllib.request as urllib2
+import urllib.request as urllib2
 
-    file = io.FileIO
-#    import urllib.error as ??
-#    from . import metalink
-
-# import logging
+file = io.FileIO
 import base64
 import binascii
 import copy
 import ftplib
 import gettext
 
-# import utils
 import hashlib
 import locale
 import os
@@ -90,13 +76,10 @@ import socket
 import ssl
 import threading
 
-# import thread
 import time
 import uuid
 
 import metalink
-
-# import logging
 
 
 try:
@@ -119,24 +102,24 @@ except ImportError:
 
 try:
     import win32api
-except:
+except ImportError:
     pass
 
 try:
     import win32con
-except:
+except ImportError:
     pass
 
-# Need python 2.7.9 or newer for the really good stuff
-if sys.version_info[0] >= 2 and sys.version_info[1] >= 7 and sys.version_info[2] >= 9:
-    SSL_ANYTHING = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-    SSL_DEFAULT = ssl.create_default_context()
-    SSL_HIGH = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-    SSL_HIGH.verify_mode = ssl.CERT_REQUIRED
-    SSL_HIGH.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
-    SSL_HIGH.set_ciphers(
-        "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK"
-    )
+# Deprecated since Python version 3.6
+# OpenSSL has deprecated all version specific protocols.
+SSL_ANYTHING = ssl.SSLContext(ssl.PROTOCOL_TLS)  # previously, ssl.PROTOCOL_SSLv23
+SSL_DEFAULT = ssl.create_default_context()
+SSL_HIGH = ssl.SSLContext(ssl.PROTOCOL_TLS)  # previously, ssl.PROTOCOL_TLSv1_2
+SSL_HIGH.verify_mode = ssl.CERT_REQUIRED
+SSL_HIGH.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
+SSL_HIGH.set_ciphers(
+    "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK"
+)
 
 USER_AGENT = "pyMetalink/6.1 +https://github.com/metalink-dev/pymetalink/"
 UUID = None
@@ -154,8 +137,8 @@ LANG = []
 OS = None
 COUNTRY = None
 
-lang = locale.getdefaultlocale()[0]
-if lang == None:
+lang = locale.getlocale()[0]
+if lang is None:
     lang = "LC_ALL"
 lang = lang.replace("_", "-").lower()
 LANG = [lang]
@@ -182,9 +165,7 @@ DIGESTS = "md5,sha,sha-256,sha-384,sha-512"
 
 
 def translate():
-    """
-    Setup translation path
-    """
+    """Setup translation path."""
     if __name__ == "__main__":
         base = ""
         localedir = ""
@@ -192,7 +173,7 @@ def translate():
             base = os.path.basename(__file__)[:-3]
             localedir = os.path.join(os.path.dirname(__file__), "locale")
         except NameError:
-            if sys.executable != None:
+            if sys.executable is not None:
                 base = os.path.basename(sys.executable)[:-4]
                 localedir = os.path.join(os.path.dirname(sys.executable), "locale")
     else:
@@ -201,15 +182,11 @@ def translate():
         localedir = os.path.join("/".join(["%s" % k for k in temp[:-1]]), "locale")
 
     # print base, localedir
-    localelang = locale.getdefaultlocale()[0]
-    if localelang == None:
-        localelang = "LC_ALL"
-    t = gettext.translation(base, localedir, [localelang], None, "en")
-    try:
-        return t.ugettext
-    # python3
-    except:
-        return t.gettext
+    locale_lang = locale.getlocale()[0]
+    if locale_lang is None:
+        locale_lang = "LC_ALL"
+    t = gettext.translation(base, localedir, [locale_lang], None, "en")
+    return t.gettext
 
 
 _ = translate()
@@ -309,7 +286,7 @@ def digest_parse(digest):
 
 
 def get(
-    src, path, checksums={}, force=False, handlers={}, segmented=SEGMENTED, headers={}
+    src, path, checksums=None, force=False, handlers=None, segmented=SEGMENTED, headers=None
 ):
     """
     Download a file, decodes metalinks.
@@ -323,12 +300,19 @@ def get(
     Returns False otherwise (checksum fails)
     raise socket.error e.g. "Operation timed out"
     """
+    if checksums is None:
+        checksums = {}
+    if handlers is None:
+        handlers = {}
+    if headers is None:
+        headers = {}
+
     if src.endswith(".jigdo"):
         return download_jigdo(src, path, force, handlers, segmented, headers)
     # assume metalink if ends with .metalink
 
     result = download_metalink(src, path, force, handlers, segmented, headers)
-    if result != None:
+    if result is not None:
         return result
 
     # assume normal file download here
@@ -353,13 +337,13 @@ def download_file(
     url,
     local_file,
     size=0,
-    checksums={},
+    checksums=None,
     force=False,
-    handlers={},
+    handlers=None,
     segmented=SEGMENTED,
-    chunksums={},
+    chunksums=None,
     chunk_size=0,
-    headers={},
+    headers=None,
 ):
     """
     url {string->URL} locations of the file
@@ -373,9 +357,14 @@ def download_file(
     returns unicode Returns file path if download is successful.
         Returns False otherwise (checksum fails).
     """
-    # convert string filename into something we can use
-    # urllist = {}
-    # urllist[url] = URL(url)
+    if checksums is None:
+        checksums = {}
+    if handlers is None:
+        handlers = {}
+    if chunksums is None:
+        chunksums = {}
+    if headers is None:
+        headers = {}
 
     fileobj = metalink.MetalinkFile(local_file)
     # Need to set this again for absolute file paths
@@ -390,7 +379,7 @@ def download_file(
 
 
 def download_file_urls(
-    metalinkfile, force=False, handlers={}, segmented=SEGMENTED, headers={}
+    metalinkfile, force=False, handlers=None, segmented=SEGMENTED, headers=None
 ):
     """
     Download a file.
@@ -401,13 +390,17 @@ def download_file_urls(
     Returns file path if download is successful
     Returns False otherwise (checksum fails)
     """
+    if handlers is None:
+        handlers = {}
+    if headers is None:
+        headers = {}
 
     if os.path.exists(metalinkfile.filename) and (not force):
-        actsize = os.stat(metalinkfile.filename).st_size
+        act_size = os.stat(metalinkfile.filename).st_size
         if len(metalinkfile.hashlist) > 0:
             checksum = verify_checksum(metalinkfile.filename, metalinkfile.hashlist)
             if checksum:
-                handlers["status"](1, actsize, actsize)
+                handlers["status"](1, act_size, act_size)
                 print("")
                 print(
                     _("Already downloaded %s.")
@@ -420,9 +413,9 @@ def download_file_urls(
                     % os.path.basename(metalinkfile.filename)
                 )
 
-        if metalinkfile.size == actsize:
+        if metalinkfile.size == act_size:
             if "status" in handlers:
-                handlers["status"](1, actsize, actsize)
+                handlers["status"](1, act_size, act_size)
             print("")
             print(_("Already downloaded %s.") % os.path.basename(metalinkfile.filename))
             return metalinkfile.filename
@@ -461,8 +454,9 @@ def download_file_urls(
         manager.set_callbacks(handlers)
         manager.run()
 
-    if manager.get_status():
-        return metalinkfile.filename
+    if manager is not None:
+        if manager.get_status():
+            return metalinkfile.filename
     return False
 
 
@@ -502,11 +496,11 @@ class Manager:
         """
         result = self.status
         while result:
-            if self.pause_handler != None and self.pause_handler():
+            if self.pause_handler is not None and self.pause_handler():
                 self.end_bitrate()
                 time.sleep(1)
             else:
-                if wait != None:
+                if wait is not None:
                     time.sleep(wait)
                 result = self.cycle()
 
@@ -539,7 +533,7 @@ class Manager:
         """
         Pass in current byte count
         """
-        if self.oldtime != None and (time.time() - self.oldtime) != 0:
+        if self.oldtime is not None and (time.time() - self.oldtime) != 0:
             return ((bytes - self.oldsize) * 8 / 1024) / (time.time() - self.oldtime)
         return 0
 
@@ -579,7 +573,7 @@ class NormalManager(Manager):
         self.number = self.start_number
 
     def cycle(self):
-        if self.cancel_handler != None and self.cancel_handler():
+        if self.cancel_handler is not None and self.cancel_handler():
             return False
         try:
             self.status = True
@@ -653,7 +647,7 @@ class URLManager(Manager):
             self.size = 0
 
         self.streamserver = None
-        if PORT != None:
+        if PORT is not None:
             self.streamserver = StreamServer((HOST, PORT), StreamRequest)
             self.streamserver.set_stream(self.data)
 
@@ -664,7 +658,7 @@ class URLManager(Manager):
     def close_handler(self):
         self.resume.complete()
         try:
-            if PORT == None:
+            if PORT is None:
                 self.data.close()
             self.temp.close()
         except:
@@ -674,9 +668,9 @@ class URLManager(Manager):
             self.status = filecheck(self.filename, self.checksums, self.size)
 
     def cycle(self):
-        if self.oldtime == None:
+        if self.oldtime is None:
             self.start_bitrate(self.counter * self.block_size)
-        if self.cancel_handler != None and self.cancel_handler():
+        if self.cancel_handler is not None and self.cancel_handler():
             self.close_handler()
             return False
 
@@ -689,16 +683,16 @@ class URLManager(Manager):
 
         self.resume.set_block_size(self.counter * self.block_size)
 
-        if self.streamserver != None:
+        if self.streamserver is not None:
             self.streamserver.set_length(self.counter * self.block_size)
 
-        if self.status_handler != None:
+        if self.status_handler is not None:
             self.status_handler(self.total, 1, self.size)
 
-        if self.bitrate_handler != None:
+        if self.bitrate_handler is not None:
             self.bitrate_handler(self.get_bitrate(self.counter * self.block_size))
 
-        if self.time_handler != None:
+        if self.time_handler is not None:
             self.time_handler(self.get_time(self.counter * self.block_size))
 
         if not block:
@@ -716,7 +710,7 @@ def filecheck(local_file, checksums, size, handler=None):
         except:
             pass
 
-        if handler != None:
+        if handler is not None:
             tempsize = size
             if size == 0:
                 tempsize = actsize
@@ -729,7 +723,10 @@ def filecheck(local_file, checksums, size, handler=None):
     return False
 
 
-def parse_metalink(src, headers={}, nocheck=False, ver=3):
+def parse_metalink(src, headers=None, nocheck=False, ver=3):
+    if headers is None:
+        headers = {}
+
     src = complete_url(src)
     is_metalink = nocheck
 
@@ -739,17 +736,17 @@ def parse_metalink(src, headers={}, nocheck=False, ver=3):
         is_metalink = True
     try:
         # add head check for metalink type, if MIME_TYPE or application/xml? treat as metalink
-        myheaders = urlhead(src, metalink_header=True, headers=headers)
-        if myheaders["content-type"].startswith(MIME_TYPE):
+        my_headers = urlhead(src, metalink_header=True, headers=headers)
+        if my_headers["content-type"].startswith(MIME_TYPE):
             print(_("Metalink content-type detected."))
             is_metalink = True
-        elif myheaders["link"]:
+        elif my_headers["link"]:
             # Metalink HTTP Link headers implementation, RFC 6249
             # does not check for describedby urls but we can't use any of those anyway
             # TODO this should be more robust and ignore commas in <> for urls
-            links = myheaders["link"].split(",")
+            links = my_headers["link"].split(",")
             fileobj = metalink.MetalinkFile4(os.path.basename(src))
-            fileobj.set_size(myheaders["content-length"])
+            fileobj.set_size(my_headers["content-length"])
             for link in links:
                 parts = link.split(";")
                 mydict = {}
@@ -793,7 +790,7 @@ def parse_metalink(src, headers={}, nocheck=False, ver=3):
                 except KeyError:
                     pass
             try:
-                fileobj.hashlist = digest_parse(myheaders["digest"])
+                fileobj.hashlist = digest_parse(my_headers["digest"])
             except KeyError:
                 # RFC requires link headers to be ignored if no digest header, use standard download method
                 return False
@@ -832,23 +829,28 @@ def parse_rss(src, headers={}):
 
 
 def download_rss(
-    src, path, force=False, handlers={}, segmented=SEGMENTED, headers={}, nocheck=False
+    src, path, force=False, handlers=None, segmented=SEGMENTED, headers=None, nocheck=False
 ):
-    rssobj = parse_rss(src, headers)
-    if not rssobj:
+    if handlers is None:
+        handlers = {}
+    if headers is None:
+        headers = {}
+
+    rss_obj = parse_rss(src, headers)
+    if not rss_obj:
         return False
 
-    urllist = rssobj.files
-    if len(urllist) == 0:
+    url_list = rss_obj.files
+    if len(url_list) == 0:
         print(_("No enclosures to download files from."))
         return False
 
     results = []
-    for rssitem in urllist:
+    for rss_item in url_list:
         result = download_file(
-            rssitem.url,
-            os.path.join(path, os.path.basename(rssitem.url)),
-            rssitem.size,
+            rss_item.url,
+            os.path.join(path, os.path.basename(rss_item.url)),
+            rss_item.size,
             force=force,
             handlers=handlers,
             segmented=segmented,
@@ -863,52 +865,57 @@ def download_rss(
 
 
 def download_metalink(
-    src, path, force=False, handlers={}, segmented=SEGMENTED, headers={}, nocheck=False
+    src, path, force=False, handlers=None, segmented=SEGMENTED, headers=None, nocheck=False
 ):
     """
     Decode a metalink file, can be local or remote
     First parameter, file to download, URL, file path or Metalink object to download from
     Second parameter, file path to save to
     Third parameter, optional, force a new download even if a valid copy already exists
-    Fouth parameter, optional, progress handler callback
+    Fourth parameter, optional, progress handler callback
     Returns list of file paths if download(s) is successful
     Returns None is the file is not a metalink file (parse_metalink output is False)
     Returns False otherwise (checksum fails)
     """
-    myheaders = headers.copy()
+    if handlers is None:
+        handlers = {}
+    if headers is None:
+        headers = {}
 
-    metalinkobj = parse_metalink(src, myheaders, nocheck)
-    if not metalinkobj:
+    my_headers = headers.copy()
+
+    metalink_obj = parse_metalink(src, my_headers, nocheck)
+    if not metalink_obj:
         return None
 
     if is_remote(src):
-        myheaders["referer"] = src
+        my_headers["referer"] = src
 
-    if metalinkobj.type == "dynamic":
-        origin = metalinkobj.origin
+    if metalink_obj.type == "dynamic":
+        origin = metalink_obj.origin
         if origin != src and origin != "":
             print(_("Downloading update from %s") % origin)
             try:
                 return download_metalink(
-                    origin, path, force, handlers, segmented, myheaders
+                    origin, path, force, handlers, segmented, my_headers
                 )
             except:
                 pass
 
-    urllist = metalinkobj.files
-    if len(urllist) == 0:
+    url_list = metalink_obj.files
+    if len(url_list) == 0:
         print(_("No urls to download file from."))
         return False
 
     results = []
-    for filenode in urllist:
+    for filenode in url_list:
         ostag = filenode.os
         langtag = filenode.language
 
-        if OS == None or len(ostag) == 0 or ostag[0].lower() == OS.lower():
+        if OS is None or len(ostag) == 0 or ostag[0].lower() == OS.lower():
             if "any" in LANG or len(langtag) == 0 or langtag.lower() in LANG:
                 result = download_file_node(
-                    filenode, path, force, handlers, segmented, myheaders
+                    filenode, path, force, handlers, segmented, my_headers
                 )
                 if result:
                     results.append(result)
@@ -919,20 +926,25 @@ def download_metalink(
 
 
 def download_jigdo(
-    src, path, force=False, handlers={}, segmented=SEGMENTED, headers={}
+    src, path, force=False, handlers=None, segmented=SEGMENTED, headers=None
 ):
     """
     Decode a jigdo file, can be local or remote
     First parameter, file to download, URL or file path to download from
     Second parameter, file path to save to
     Third parameter, optional, force a new download even if a valid copy already exists
-    Fouth parameter, optional, progress handler callback
+    Fourth parameter, optional, progress handler callback
     Returns list of file paths if download(s) is successful
     Returns False otherwise (checksum fails)
     """
-    newsrc = complete_url(src)
+    if handlers is None:
+        handlers = {}
+    if headers is None:
+        headers = {}
+
+    new_src = complete_url(src)
     try:
-        datasource = urlopen(newsrc, metalink_header=True, headers=headers)
+        datasource = urlopen(new_src, metalink_header=True, headers=headers)
     except:
         return False
 
@@ -954,15 +966,15 @@ def download_jigdo(
         print(_("Could not download template file!"))
         return False
 
-    urllist = jigdo.files
-    if len(urllist) == 0:
+    url_list = jigdo.files
+    if len(url_list) == 0:
         print(_("No urls to download file from."))
         return False
 
     results = []
     results.extend(template)
-    for filenode in urllist:
-        result = download_file_node(filenode, path, force, handlers, segmented, headers)
+    for file_node in url_list:
+        result = download_file_node(file_node, path, force, handlers, segmented, headers)
         if result:
             results.append(result)
     if len(results) == 0:
@@ -977,16 +989,18 @@ def download_jigdo(
     return results
 
 
-def convert_jigdo(src, headers={}):
+def convert_jigdo(src, headers=None):
     """
     Decode a jigdo file, can be local or remote
     First parameter, file to download, URL or file path to download from
     Returns metalink xml text, False on error
     """
+    if headers is None:
+        headers = {}
 
-    newsrc = complete_url(src)
+    new_src = complete_url(src)
     try:
-        datasource = urlopen(newsrc, metalink_header=True, headers=headers)
+        datasource = urlopen(new_src, metalink_header=True, headers=headers)
     except:
         return False
 
@@ -999,8 +1013,8 @@ def convert_jigdo(src, headers={}):
     fileobj.add_checksum("md5", jigdo.template_md5)
     jigdo.files.insert(0, fileobj)
 
-    urllist = jigdo.files
-    if len(urllist) == 0:
+    url_list = jigdo.files
+    if len(url_list) == 0:
         print(_("No Jigdo data files!"))
         return False
 
@@ -1008,24 +1022,25 @@ def convert_jigdo(src, headers={}):
 
 
 def download_file_node(
-    item, path, force=False, handler=None, segmented=SEGMENTED, headers={}
+    item, path, force=False, handler=None, segmented=SEGMENTED, headers=None
 ):
     """
     First parameter, file XML node
     Second parameter, file path to save to
     Third parameter, optional, force a new download even if a valid copy already exists
-    Fouth parameter, optional, progress handler callback
+    Fourth parameter, optional, progress handler callback
     Returns list of file paths if download(s) is successful
     Returns False otherwise (checksum fails)
     raise socket.error e.g. "Operation timed out"
     """
+    if headers is None:
+        headers = {}
 
-    urllist = []
-
+    url_list = []
     for node in item.resources:
-        urllist.append(node.url)
+        url_list.append(node.url)
 
-    if len(urllist) == 0:
+    if len(url_list) == 0:
         print(_("No urls to download file from."))
         return False
 
@@ -1043,25 +1058,26 @@ def complete_url(url):
     Returns, string converted to URL format
     """
     if get_transport(url) == "":
-        absfile = os.path.abspath(url)
-        if absfile[0] != "/":
-            absfile = "/" + absfile
-        return "file://" + absfile
+        abs_file = os.path.abspath(url)
+        if abs_file[0] != "/":
+            abs_file = "/" + abs_file
+        return "file://" + abs_file
     return url
 
 
-def urlretrieve(url, filename, reporthook=None, headers={}):
-    """
-    modernized replacement for urllib.urlretrieve() for use with proxy
-    """
+def urlretrieve(url, filename, reporthook=None, headers=None):
+    """Modernized replacement for urllib.urlretrieve() for use with proxy."""
+    if headers is None:
+        headers = {}
+
     block_size = 1024
     i = 0
     counter = 0
     temp = urlopen(url, headers=headers)
-    myheaders = temp.info()
+    my_headers = temp.info()
 
     try:
-        size = int(myheaders["Content-Length"])
+        size = int(my_headers["Content-Length"])
     except KeyError:
         size = 0
 
@@ -1080,8 +1096,7 @@ def urlretrieve(url, filename, reporthook=None, headers={}):
 
         resume.set_block_size(counter * block_size)
 
-        if reporthook != None:
-            # print counter, block_size, size
+        if reporthook is not None:
             reporthook(counter, block_size, size)
 
     resume.complete()
@@ -1089,7 +1104,7 @@ def urlretrieve(url, filename, reporthook=None, headers={}):
     data.close()
     temp.close()
 
-    return (filename, headers)
+    return filename, headers
 
 
 class FileResume:
@@ -1117,7 +1132,7 @@ class FileResume:
         if self.size == size:
             return
 
-        newblocks = []
+        new_blocks = []
         count = 0
         total = 0
         offset = None
@@ -1125,23 +1140,23 @@ class FileResume:
         for value in self.blocks:
             value = int(value)
             if value == count:
-                if offset == None:
+                if offset is None:
                     offset = count
                 total += self.size
-            elif offset != None:
+            elif offset is not None:
                 start = (offset * self.size) / size
-                newblocks.extend(map(str, range(start, start + (total / size))))
+                new_blocks.extend(map(str, range(start, start + (total / size))))
                 total = 0
                 offset = None
             count += 1
 
-        if offset != None:
+        if offset is not None:
             start = int((offset * self.size) / size)
             # print(str, start, total, size)
             # print(range(start, int(start + (total / size))))
-            newblocks.extend(map(str, range(start, int(start + (total / size)))))
+            new_blocks.extend(map(str, range(start, int(start + (total / size)))))
 
-        self.blocks = newblocks
+        self.blocks = new_blocks
         self.set_block_size(size)
 
     def start_byte(self):
@@ -1202,8 +1217,8 @@ class FileResume:
     def _read(self):
         try:
             filehandle = open(self.filename, "r")
-            resumestr = filehandle.readline()
-            (size, blocks) = resumestr.split(":")
+            resume_str = filehandle.readline()
+            (size, blocks) = resume_str.split(":")
             self.blocks = blocks.split(",")
             self.size = int(size)
             filehandle.close()
@@ -1218,7 +1233,7 @@ class FileResume:
         os.remove(self.filename)
 
 
-def verify_chunk_checksum(chunkstring, checksums={}):
+def verify_chunk_checksum(chunkstring, checksums=None):
     """
     Verify the checksum of a file
     First parameter, filename
@@ -1227,53 +1242,28 @@ def verify_chunk_checksum(chunkstring, checksums={}):
     Returns True if no checksums are provided
     Returns False otherwise
     """
+    if checksums is None:
+        checksums = {}
 
-    try:
-        checksums["sha512"]
-        if hashlib.sha512(chunkstring).hexdigest() == checksums["sha512"].lower():
-            return True
-        else:
-            return False
-    except (KeyError, AttributeError):
-        pass
-    try:
-        checksums["sha384"]
-        if hashlib.sha384(chunkstring).hexdigest() == checksums["sha384"].lower():
-            return True
-        else:
-            return False
-    except (KeyError, AttributeError):
-        pass
-    try:
-        checksums["sha256"]
-        if hashlib.sha256(chunkstring).hexdigest() == checksums["sha256"].lower():
-            return True
-        else:
-            return False
-    except (KeyError, AttributeError):
-        pass
-    try:
-        checksums["sha1"]
-        if hashlib.sha1(chunkstring).hexdigest() == checksums["sha1"].lower():
-            return True
-        else:
-            return False
-    except KeyError:
-        pass
-    try:
-        checksums["md5"]
-        if hashlib.md5(chunkstring).hexdigest() == checksums["md5"].lower():
-            return True
-        else:
-            return False
-    except KeyError:
-        pass
+    hash_algorithms = ['sha512', 'sha384', 'sha256', 'sha1', 'md5']
+
+    for algorithm in hash_algorithms:
+        try:
+            if checksums.get(algorithm):
+                hash_obj = hashlib.new(algorithm)
+                hash_obj.update(chunkstring)
+                if hash_obj.hexdigest() == checksums[algorithm].lower():
+                    return True
+                else:
+                    return False
+        except (KeyError, AttributeError):
+            pass
 
     # No checksum provided, assume OK
     return True
 
 
-def verify_checksum(local_file, checksums={}):
+def verify_checksum(local_file, checksums=None):
     """
     Verify the checksum of a file
     First parameter, filename
@@ -1282,6 +1272,8 @@ def verify_checksum(local_file, checksums={}):
     Returns True if no checksums are provided
     Returns False otherwise
     """
+    if checksums is None:
+        checksums = {}
 
     try:
         return pgp_verify_sig(local_file, checksums["pgp"])
@@ -1348,7 +1340,7 @@ def pgp_verify_sig(filename, sig):
     sign = gpg.verify_file_detached(filename, sig)
 
     print("\n-----" + _("BEGIN PGP SIGNATURE INFORMATION") + "-----")
-    if sign.error != None:
+    if sign.error is not None:
         print(sign.error)
     else:
         # print sig.creation_date
@@ -1367,7 +1359,7 @@ def pgp_verify_sig(filename, sig):
         print("" + _("uid") + ":", sign.username)
     print("-----" + _("END PGP SIGNATURE INFORMATION") + "-----\n")
 
-    if sign.error != None:
+    if sign.error is not None:
         raise AssertionError(sign.error)
 
     if sign.is_valid():
@@ -1449,31 +1441,29 @@ def path_join(first, second):
 
 def start_sort(urldict):
     urls = copy.deepcopy(urldict)
-    localurls = {}
-    if COUNTRY != None:
+    local_urls = {}
+    if COUNTRY is not None:
         for url in list(urls):
             if COUNTRY.lower() == urls[url].location.lower():
-                localurls[url] = urls[url]
+                local_urls[url] = urls[url]
                 urls.pop(url)
 
-    newurls = sort_prefs(localurls)
-    newurls.extend(sort_prefs(urls))
-    # for i in range(len(newurls)):
-    #    print i, newurls[i]
-    return newurls
+    new_urls = sort_prefs(local_urls)
+    new_urls.extend(sort_prefs(urls))
+    return new_urls
 
 
 def sort_prefs(mydict):
-    newurls = []
+    new_urls = []
 
     for url in list(mydict):
-        newurls.append((mydict[url].preference, mydict[url].url))
+        new_urls.append((mydict[url].preference, mydict[url].url))
 
-    newurls.sort()
-    newurls.reverse()
+    new_urls.sort()
+    new_urls.reverse()
 
     result = []
-    for url in newurls:
+    for url in new_urls:
         result.append(url[1])
     return result
 
@@ -1524,23 +1514,23 @@ class Segment_Manager(Manager):
         self.resume = FileResume(self.localfile + ".temp")
 
         self.streamserver = None
-        if PORT != None:
+        if PORT is not None:
             self.streamserver = StreamServer((HOST, PORT), StreamRequest)
             self.streamserver.set_stream(self.f)
 
             # thread.start_new_thread(self.streamserver.serve, ())
-            mythread = threading.Thread(target=self.streamserver.serve)
-            mythread.start()
+            my_thread = threading.Thread(target=self.streamserver.serve)
+            my_thread.start()
 
     def get_chunksum(self, index):
-        mylist = {}
+        my_list = {}
         try:
             for key in self.chunksums.keys():
-                mylist[key] = self.chunksums[key][index]
-        except:
+                my_list[key] = self.chunksums[key][index]
+        except (KeyError, IndexError):
             pass
 
-        return mylist
+        return my_list
 
     def get_size(self):
         """
@@ -1565,10 +1555,9 @@ class Segment_Manager(Manager):
                     status == httplib.MOVED_PERMANENTLY or status == httplib.FOUND
                 ) and count < MAX_REDIRECTS:
                     http = Http_Host(url)
-                    if http.conn != None:
+                    if http.conn is not None:
                         try:
-                            headers = {}
-                            headers["Want-Digest"] = DIGESTS
+                            headers = {"Want-Digest": DIGESTS}
                             headers.update(self.headers)
                             http.conn.request("HEAD", url, headers=headers)
                             response = http.conn.getresponse()
@@ -1583,7 +1572,7 @@ class Segment_Manager(Manager):
                         http.close()
                     count += 1
 
-                if (status == httplib.OK) and (size != None):
+                if (status == httplib.OK) and (size is not None):
                     sizes.append(size)
                     if len(checksum_dict) > 0:
                         checksums.append(checksum_dict)
@@ -1596,7 +1585,7 @@ class Segment_Manager(Manager):
                 except ftplib.error_perm:
                     size = None
 
-                if size != None:
+                if size is not None:
                     sizes.append(size)
 
             i += 1
@@ -1621,13 +1610,12 @@ class Segment_Manager(Manager):
         return None
 
     def filter_urls(self):
-        # print self.urls
-        newurls = {}
+        new_urls = {}
         for item in list(self.urls.keys()):
             if (not item.endswith(".torrent")) and (get_transport(item) in PROTOCOLS):
-                newurls[item] = self.urls[item]
-        self.urls = newurls
-        return newurls
+                new_urls[item] = self.urls[item]
+        self.urls = new_urls
+        return new_urls
 
     def run(self, wait=0.1):
         """
@@ -1636,7 +1624,7 @@ class Segment_Manager(Manager):
         # try:
         if self.size == "" or self.size == 0:
             self.size = self.get_size()
-            if self.size == None:
+            if self.size is None:
                 # crap out and do it the old way
                 self.close_handler()
                 self.status = False
@@ -1656,17 +1644,18 @@ class Segment_Manager(Manager):
         Returns True if still downloading, False otherwise
         """
         try:
-            bytes = self.byte_total()
+            # Renamed to _bytes to not overshadow built-in bytes
+            _bytes = self.byte_total()
 
             index = self.get_chunk_index()
-            if index != None and index > 0 and self.streamserver != None:
+            if index is not None and index > 0 and self.streamserver is not None:
                 self.streamserver.set_length((index - 1) * self.chunk_size)
 
-            if self.oldtime == None:
-                self.start_bitrate(bytes)
+            if self.oldtime is None:
+                self.start_bitrate(_bytes)
 
             # cancel was pressed here
-            if self.cancel_handler != None and self.cancel_handler():
+            if self.cancel_handler is not None and self.cancel_handler():
                 self.status = False
                 self.close_handler()
                 return False
@@ -1674,7 +1663,7 @@ class Segment_Manager(Manager):
             self.update()
             self.resume.extend_blocks(self.chunk_list())
 
-            if bytes >= self.size and self.active_count() == 0:
+            if _bytes >= self.size and self.active_count() == 0:
                 self.resume.complete()
                 self.close_handler()
                 return False
@@ -1693,40 +1682,41 @@ class Segment_Manager(Manager):
             return False
 
     def update(self):
-        if self.status_handler != None and self.size != None:
+        if self.status_handler is not None and self.size is not None:
             # count = int(self.byte_total()/self.chunk_size)
             # if self.byte_total() % self.chunk_size:
             #    count += 1
             # self.status_handler(count, self.chunk_size, self.size)
             self.status_handler(self.byte_total(), 1, self.size)
-        if self.bitrate_handler != None:
+        if self.bitrate_handler is not None:
             self.bitrate_handler(self.get_bitrate(self.byte_total()))
-        if self.time_handler != None:
+        if self.time_handler is not None:
             self.time_handler(self.get_time(self.byte_total()))
 
-        next = self.next_url()
+        # Rename to _next to not overshadow built-in next
+        _next = self.next_url()
 
-        if next == None:
+        if _next is None:
             return
 
         index = self.get_chunk_index()
-        if index != None:
+        if index is not None:
             start = index * self.chunk_size
             end = start + self.chunk_size
             if end > self.size:
                 end = self.size
 
-            if next.protocol == "http" or next.protocol == "https":
+            if _next.protocol == "http" or _next.protocol == "https":
                 segment = Http_Host_Segment(
-                    next, start, end, self.size, self.get_chunksum(index), self.headers
+                    _next, start, end, self.size, self.get_chunksum(index), self.headers
                 )
                 segment.set_cancel_callback(self.cancel_handler)
                 self.chunks[index] = segment
                 self.segment_init(index)
-            if next.protocol == "ftp":
+            if _next.protocol == "ftp":
                 # print "allocated to:", index, next.url
                 segment = Ftp_Host_Segment(
-                    next, start, end, self.size, self.get_chunksum(index)
+                    _next, start, end, self.size, self.get_chunksum(index)
                 )
                 segment.set_cancel_callback(self.cancel_handler)
                 self.chunks[index] = segment
@@ -1736,7 +1726,7 @@ class Segment_Manager(Manager):
         segment = self.chunks[index]
         if str(index) in self.resume.blocks:
             segment.end()
-            if segment.error == None:
+            if segment.error is None:
                 segment.bytes = segment.byte_count
             else:
                 self.resume.remove_block(index)
@@ -1746,7 +1736,7 @@ class Segment_Manager(Manager):
     def get_chunk_index(self):
         i = -1
         for i in range(len(self.chunks)):
-            if self.chunks[i] == None or self.chunks[i].error != None:
+            if self.chunks[i] is None or self.chunks[i].error is not None:
                 return i
             # weed out dead segments that have temp errors and reassign
             if not self.chunks[i].isAlive() and self.chunks[i].bytes == 0:
@@ -1800,12 +1790,12 @@ class Segment_Manager(Manager):
         countvar = 1
         while countvar <= len(self.urls):
             try:
-                tempcount = count[urls[number]]
+                temp_count = count[urls[number]]
             except KeyError:
-                tempcount = 0
+                temp_count = 0
             # check against limits
-            if ((tempcount == 0) and (len(count) < self.host_limit)) or (
-                0 < tempcount < self.limit_per_host
+            if ((temp_count == 0) and (len(count) < self.host_limit)) or (
+                0 < temp_count < self.limit_per_host
             ):
                 # check protocol type here
                 protocol = get_transport(urls[number])
@@ -1823,9 +1813,8 @@ class Segment_Manager(Manager):
                         socket.timeout,
                         ftplib.error_temp,
                         ftplib.error_perm,
-                        socket.error,
+                        OSError
                     ):
-                        # print "FTP connect failed %s" % self.urls[number]
                         self.urls.pop(urls[number])
                         return None
                     self.sockets.append(host)
@@ -1838,32 +1827,27 @@ class Segment_Manager(Manager):
 
     def remove_errors(self):
         for item in self.chunks:
-            if item != None and item.error != None:
-                # print item.error
+            if item is not None and item.error is not None:
                 if (
                     item.error == httplib.MOVED_PERMANENTLY
                     or item.error == httplib.FOUND
                 ):
-                    # print "location:", item.location
                     try:
-                        newitem = copy.deepcopy(self.urls[item.url])
-                        newitem.url = item.location
-                        self.urls[item.location] = newitem
+                        new_item = copy.deepcopy(self.urls[item.url])
+                        new_item.url = item.location
+                        self.urls[item.location] = new_item
                     except KeyError:
                         pass
                     self.filter_urls()
 
-                # print "removed %s" % item.url
                 try:
                     self.urls.pop(item.url)
                 except KeyError:
                     pass
 
-        for socketitem in self.sockets:
-            if socketitem.url not in self.urls.keys():
-                # print socketitem.url
-                # socketitem.close()
-                self.sockets.remove(socketitem)
+        for socket_item in self.sockets:
+            if socket_item.url not in self.urls.keys():
+                self.sockets.remove(socket_item)
 
         return
 
@@ -1872,9 +1856,9 @@ class Segment_Manager(Manager):
         count = 0
         for item in self.chunks:
             try:
-                if item.error == None:
+                if item.error is None:
                     total += item.bytes
-            except (AttributeError):
+            except AttributeError:
                 pass
             count += 1
         return total
@@ -1886,13 +1870,13 @@ class Segment_Manager(Manager):
             try:
                 if self.chunks[i].bytes == self.chunk_size:
                     chunks.append(i)
-            except (AttributeError):
+            except AttributeError:
                 pass
         # print chunks
         return chunks
 
     def close_handler(self):
-        if PORT == None:
+        if PORT is None:
             self.f.close()
         for host in self.sockets:
             host.close()
@@ -1905,7 +1889,7 @@ class Segment_Manager(Manager):
             try:
                 os.remove(self.localfile)
                 os.remove(self.localfile + ".temp")
-            except:
+            except OSError:
                 pass
             self.status = False
         elif self.status:
@@ -1950,32 +1934,30 @@ class Ftp_Host(Host_Base):
 
     def connect(self):
         if self.protocol == "ftp":
-            urlparts = urlparse.urlsplit(self.url)
+            url_parts = urlparse.urlsplit(self.url)
             try:
-                username = urlparts.username
-                password = urlparts.password
+                username = url_parts.username
+                password = url_parts.password
             except AttributeError:
                 # needed for python < 2.5
                 username = None
 
-            if username == None:
+            if username is None:
                 username = "anonymous"
                 password = "anonymous"
             try:
-                port = urlparts.port
+                port = url_parts.port
             except:
                 port = ftplib.FTP_PORT
-            if port == None:
+            if port is None:
                 port = ftplib.FTP_PORT
 
             self.conn = proxy.FTP()
-            self.conn.connect(urlparts[1], port)
+            self.conn.connect(url_parts[1], port)
             try:
                 self.conn.login(username, password)
             except:
-                # self.error = "login failed"
                 raise
-                return
             # set to binary mode, only works when not proxied
             try:
                 self.conn.voidcmd("TYPE I")
@@ -1987,7 +1969,7 @@ class Ftp_Host(Host_Base):
             # return
 
     def close(self):
-        if self.conn != None:
+        if self.conn is not None:
             try:
                 self.conn.quit()
             except:
@@ -2011,7 +1993,7 @@ class Http_Host(Host_Base):
                 port = urlparts.port
             except:
                 port = httplib.HTTP_PORT
-            if port == None:
+            if port is None:
                 port = httplib.HTTP_PORT
             try:
                 self.conn = proxy.HTTPConnection(urlparts[1], port)
@@ -2023,7 +2005,7 @@ class Http_Host(Host_Base):
                 port = urlparts.port
             except:
                 port = httplib.HTTPS_PORT
-            if port == None:
+            if port is None:
                 port = httplib.HTTPS_PORT
             try:
                 self.conn = proxy.HTTPSConnection(urlparts[1], port)
@@ -2035,7 +2017,7 @@ class Http_Host(Host_Base):
             return
 
     def close(self):
-        if self.conn != None:
+        if self.conn is not None:
             self.conn.close()
 
 
@@ -2044,8 +2026,14 @@ class Host_Segment:
     Base class for various segment protocol types.  Not to be used directly.
     """
 
-    def __init__(self, host, start, end, filesize, checksums={}, headers={}):
+    def __init__(self, host, start, end, filesize, checksums=None, headers=None):
         threading.Thread.__init__(self)
+
+        if checksums is None:
+            checksums = {}
+        if headers is None:
+            headers = {}
+
         self.host = host
         self.host.set_active(True)
         self.byte_start = start
@@ -2068,7 +2056,7 @@ class Host_Segment:
         self.cancel_handler = handler
 
     def check_cancel(self):
-        if self.cancel_handler == None:
+        if self.cancel_handler is None:
             return False
         return self.cancel_handler()
 
@@ -2083,21 +2071,21 @@ class Host_Segment:
         try:
             self.mem.acquire()
             self.mem.seek(self.byte_start, 0)
-            chunkstring = self.mem.read(self.byte_count)
+            chunk_str = self.mem.read(self.byte_count)
             self.mem.release()
         except ValueError:
             return False
 
-        return verify_chunk_checksum(chunkstring, self.checksums)
+        return verify_chunk_checksum(chunk_str, self.checksums)
 
     def close(self):
-        if self.error != None:
+        if self.error is not None:
             self.host.close()
 
         self.host.set_active(False)
 
     def end(self):
-        if self.error == None and not self.checksum():
+        if self.error is None and not self.checksum():
             self.error = _("Chunk checksum failed")
         self.close()
 
@@ -2116,7 +2104,7 @@ class Ftp_Host_Segment(threading.Thread, Host_Segment):
 
         # check for supported hosts/urls
         urlparts = urlparse.urlsplit(self.url)
-        if self.host.conn == None:
+        if self.host.conn is None:
             # print "bad socket"
             self.error = _("bad socket")
             self.close()
@@ -2131,7 +2119,7 @@ class Ftp_Host_Segment(threading.Thread, Host_Segment):
                 (self.response, size) = self.host.conn.ntransfercmd(
                     "RETR " + urlparts.path, self.byte_start, self.byte_end
                 )
-            except (ftplib.error_perm) as error:
+            except ftplib.error_perm as error:
                 self.error = error.message
                 self.close()
                 return
@@ -2147,22 +2135,21 @@ class Ftp_Host_Segment(threading.Thread, Host_Segment):
                 self.error = _("AttributeError")
                 self.close()
                 return
-            except (socket.error) as error:
-                # print "reconnect", self.host.url
+            except socket.error:
                 try:
                     self.host.reconnect()
                 except:
                     pass
                 retry = True
                 count += 1
-            except (ftplib.error_temp) as error:
+            except ftplib.error_temp as error:
                 # this is not an error condition, most likely transfer TCP connection was closed
                 # count += 1
                 # self.error = "error temp", error.message
                 self.temp = error.message
                 self.close()
                 return
-            except (ftplib.error_reply) as error:
+            except ftplib.error_reply:
                 # this is likely just an extra chatty FTP server, ignore for now
                 pass
 
@@ -2171,7 +2158,7 @@ class Ftp_Host_Segment(threading.Thread, Host_Segment):
                 self.close()
                 return
 
-        if size != None:
+        if size is not None:
             if self.filesize != size:
                 self.error = _("bad file size")
                 return
@@ -2189,7 +2176,7 @@ class Ftp_Host_Segment(threading.Thread, Host_Segment):
         if self.check_cancel():
             return False
 
-        if self.response == None:
+        if self.response is None:
             return False
         return True
 
@@ -2213,15 +2200,15 @@ class Ftp_Host_Segment(threading.Thread, Host_Segment):
             except AttributeError:
                 pass
 
-            tempbuffer = self.buffer[: self.byte_count]
+            temp_buffer = self.buffer[: self.byte_count]
             self.buffer = b""
 
-            self.bytes += len(tempbuffer)
+            self.bytes += len(temp_buffer)
 
             try:
                 self.mem.acquire()
                 self.mem.seek(self.byte_start, 0)
-                self.mem.write(tempbuffer)
+                self.mem.write(temp_buffer)
                 self.mem.flush()
                 self.mem.release()
             except ValueError:
@@ -2278,7 +2265,7 @@ class Http_Host_Segment(threading.Thread, Host_Segment):
             self.close()
             return
 
-        if self.host.conn == None:
+        if self.host.conn is None:
             self.error = _("bad socket")
             self.close()
             return
@@ -2309,7 +2296,7 @@ class Http_Host_Segment(threading.Thread, Host_Segment):
         if self.check_cancel():
             return False
 
-        if self.response == None:
+        if self.response is None:
             try:
                 self.response = self.host.conn.getresponse()
             except socket.timeout:
@@ -2336,7 +2323,6 @@ class Http_Host_Segment(threading.Thread, Host_Segment):
             self.error = self.response.status
             self.response = None
             return False
-        return False
 
     def handle_read(self):
         try:
@@ -2360,8 +2346,8 @@ class Http_Host_Segment(threading.Thread, Host_Segment):
         if len(data) == 0:
             return
 
-        rangestring = self.response.getheader("Content-Range")
-        request_size = int(rangestring.split("/")[1])
+        range_str = self.response.getheader("Content-Range")
+        request_size = int(range_str.split("/")[1])
 
         if request_size != self.filesize:
             self.error = _("bad file size")
@@ -2371,15 +2357,15 @@ class Http_Host_Segment(threading.Thread, Host_Segment):
         # Check digest headers against expected
         digest = self.response.getheader("Digest", None)
         if digest is not None:
-            digestsums = digest_parse(digest)
+            digest_sums = digest_parse(digest)
             # check digest here, skip if missing, return if mismatch
             for hashtype in self.checksums.keys():
                 try:
-                    digestsums[hashtype]
+                    digest_sums[hashtype]
                 except KeyError:
                     continue
 
-                if self.checksums[hashtype] != digestsums[hashtype]:
+                if self.checksums[hashtype] != digest_sums[hashtype]:
                     return
 
         body = data
@@ -2412,7 +2398,7 @@ class StreamRequest(BaseHTTPServer.BaseHTTPRequestHandler):
 
         start = 0
         while True:
-            if self.server.fileobj != None and (self.server.length - start) > 0:
+            if self.server.fileobj is not None and (self.server.length - start) > 0:
                 try:
                     self.server.fileobj.acquire()
                     loc = self.server.fileobj.tell()
@@ -2450,7 +2436,7 @@ class StreamServer(BaseHTTPServer.HTTPServer):
                 sock, addr = self.socket.accept()
                 sock.setblocking(0)
                 sock.settimeout(30)
-                return (sock, addr)
+                return sock, addr
             except socket.timeout:
                 pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymetalink"
-version = "6.3"
+version = "0"
 description = "A metalink library for Python"
 authors = ["Neil McNab <nabber00@gmail.com>", "Bram Neijt <bram@neijt.nl>"]
 license = "MIT"
@@ -10,6 +10,9 @@ repository = "https://github.com/metalink-dev/pymetalink"
 
 [tool.poetry.dependencies]
 python = "^3.8"
+
+[tool.poetry-version-plugin]
+source = "git-tag"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
### Changes

Replaces #19 

* Added some more specific exception handling
* Synchronized the authorship across files
* Configured the GitHub Workflow to test against more Python versions
* Added `.idea` to `.gitignore` (for JetBrains IDEs)
* Publishing no longer uses `twine`, opting for native `poetry` commands
* Versioning uses git tags with the `poetry-version-plugin`
* Addressed `DeprecationWarning` message being emitted in newer versions of Python
* Cleaned up a few imports
* Updated call signatures of some functions to not assign variables on call (unsafe)

### Additional context

These are deprecation notices that were being raised in downstream projects:

* Python3.11+:
```
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/GPG.py:80
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/GPG.py:80
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/GPG.py:80
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/GPG.py:80
  /home/runner/micromamba/envs/raven/lib/python3.12/site-packages/metalink/GPG.py:80: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    localelang = locale.getdefaultlocale()[0]

../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/proxy.py:110
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/proxy.py:110
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/proxy.py:110
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/proxy.py:110
  /home/runner/micromamba/envs/raven/lib/python3.12/site-packages/metalink/proxy.py:110: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    localelang = locale.getdefaultlocale()[0]

../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:157
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:157
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:157
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:157
  /home/runner/micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:157: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    lang = locale.getdefaultlocale()[0]

../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:204
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:204
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:204
../../../micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:204
  /home/runner/micromamba/envs/raven/lib/python3.12/site-packages/metalink/download.py:204: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    localelang = locale.getdefaultlocale()[0]
```

* Specific to Python3.10 and Python3.11:
```
 ../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:132
../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:132
../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:132
../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:132
  /home/runner/micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:132: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    SSL_ANYTHING = ssl.SSLContext(ssl.PROTOCOL_SSLv23)

../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:134
../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:134
../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:134
../../../micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:134
  /home/runner/micromamba/envs/raven/lib/python3.11/site-packages/metalink/download.py:134: DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated
    SSL_HIGH = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
```

These have been addressed