### PR TITLE
Skip ed2k hash when it is not being used

### DIFF
--- a/metalink/metalink.py
+++ b/metalink/metalink.py
@@ -939,7 +939,8 @@ class MetalinkFileBase:
             self.hashlist["sha256"] = sha256hash.hexdigest()
 
         # automatically add an ed2k url here
-        ed2khash = ed2k_hash(filename)
+        if self.do_ed2k or self.do_magnet:
+            ed2khash = ed2k_hash(filename)
 
         if self.do_ed2k:
             self.ed2k = compute_ed2k(filename, ed2khash)


### PR DESCRIPTION
Adds a condition to skip the ed2k hash when it isn't being used. Fixes #32 