### PR TITLE
Restore HTTP(S) proxy support for Python 3

### DIFF
--- a/metalink/GPG.py
+++ b/metalink/GPG.py
@@ -49,6 +49,7 @@ import locale
 import os
 import os.path
 import subprocess
+from typing import Callable
 
 try:
     import win32process
@@ -56,7 +57,7 @@ except ImportError:
     pass
 
 
-def translate():
+def translate() -> Callable[[str], str]:
     """
     Setup translation path
     """
@@ -74,13 +75,16 @@ def translate():
 
     locale_lang = locale.getlocale()[0]
     if locale_lang is None:
-        locale_lang = "LC_ALL"
-    t = gettext.translation(base, localedir, [locale_lang], None, "en")
+        locale_lang = "en" # Fallback to "en" if no system locale is found
+
     try:
-        return t.ugettext
-    # python3
-    except:
-        return t.gettext
+        # Load translation
+        t = gettext.translation(domain=base, localedir=localedir, languages=[locale_lang], fallback=True)
+    except FileNotFoundError:
+        # If the translation file doesn't exist, use a fallback
+        t = gettext.NullTranslations()
+
+    return t.gettext
 
 
 _ = translate()

--- a/metalink/GPG.py
+++ b/metalink/GPG.py
@@ -75,11 +75,13 @@ def translate() -> Callable[[str], str]:
 
     locale_lang = locale.getlocale()[0]
     if locale_lang is None:
-        locale_lang = "en" # Fallback to "en" if no system locale is found
+        locale_lang = "en"  # Fallback to "en" if no system locale is found
 
     try:
         # Load translation
-        t = gettext.translation(domain=base, localedir=localedir, languages=[locale_lang], fallback=True)
+        t = gettext.translation(
+            domain=base, localedir=localedir, languages=[locale_lang], fallback=True
+        )
     except FileNotFoundError:
         # If the translation file doesn't exist, use a fallback
         t = gettext.NullTranslations()

--- a/metalink/download.py
+++ b/metalink/download.py
@@ -58,8 +58,9 @@ import http.client as httplib
 import http.server as BaseHTTPServer
 import io
 import urllib.parse as urlparse
-
 import urllib.request as urllib2
+
+from typing import List
 
 file = io.FileIO
 import base64
@@ -1499,7 +1500,7 @@ class Segment_Manager(Manager):
 
         self.headers = headers.copy()
         self.sockets = []
-        self.chunks = []
+        self.chunks: List[Http_Host_Segment] = []
         self.limit_per_host = LIMIT_PER_HOST
         self.host_limit = HOST_LIMIT
         # self.size = 0
@@ -1749,7 +1750,7 @@ class Segment_Manager(Manager):
             if self.chunks[i] is None or self.chunks[i].error is not None:
                 return i
             # weed out dead segments that have temp errors and reassign
-            if not self.chunks[i].isAlive() and self.chunks[i].bytes == 0:
+            if not self.chunks[i].is_alive() and self.chunks[i].bytes == 0:
                 return i
         i += 1
 

--- a/metalink/download.py
+++ b/metalink/download.py
@@ -72,7 +72,7 @@ import time
 import urllib.parse
 import urllib.request
 import uuid
-from typing import List
+from typing import List, Callable
 
 import metalink
 
@@ -148,7 +148,7 @@ MIME_TYPE = "application/metalink+xml"
 DIGESTS = "md5,sha,sha-256,sha-384,sha-512"
 
 
-def translate():
+def translate() -> Callable[[str], str]:
     """Setup translation path."""
     if __name__ == "__main__":
         base = ""
@@ -165,11 +165,17 @@ def translate():
         base = temp[-1]
         localedir = os.path.join("/".join(["%s" % k for k in temp[:-1]]), "locale")
 
-    # print base, localedir
-    locale_lang = locale.getlocale()[0]
+    locale_lang = locale.getdefaultlocale()[0]
     if locale_lang is None:
-        locale_lang = "LC_ALL"
-    t = gettext.translation(base, localedir, [locale_lang], None, "en")
+        locale_lang = "en" # Fallback to "en" if no system locale is found
+
+    try:
+        # Load translation
+        t = gettext.translation(domain=base, localedir=localedir, languages=[locale_lang], fallback=True)
+    except FileNotFoundError:
+        # If the translation file doesn't exist, use a fallback
+        t = gettext.NullTranslations()
+
     return t.gettext
 
 

--- a/metalink/download.py
+++ b/metalink/download.py
@@ -167,11 +167,13 @@ def translate() -> Callable[[str], str]:
 
     locale_lang = locale.getdefaultlocale()[0]
     if locale_lang is None:
-        locale_lang = "en" # Fallback to "en" if no system locale is found
+        locale_lang = "en"  # Fallback to "en" if no system locale is found
 
     try:
         # Load translation
-        t = gettext.translation(domain=base, localedir=localedir, languages=[locale_lang], fallback=True)
+        t = gettext.translation(
+            domain=base, localedir=localedir, languages=[locale_lang], fallback=True
+        )
     except FileNotFoundError:
         # If the translation file doesn't exist, use a fallback
         t = gettext.NullTranslations()
@@ -1562,7 +1564,8 @@ class Segment_Manager(Manager):
                 size = None
                 checksum_dict = {}
                 while (
-                    status == http.client.MOVED_PERMANENTLY or status == http.client.FOUND
+                    status == http.client.MOVED_PERMANENTLY
+                    or status == http.client.FOUND
                 ) and count < MAX_REDIRECTS:
                     http_host = Http_Host(url)
                     if http_host.conn is not None:
@@ -2428,7 +2431,6 @@ class StreamRequest(http.server.BaseHTTPRequestHandler):
 
 
 class StreamServer(http.server.HTTPServer):
-
     def __init__(self, *args):
         http.server.HTTPServer.__init__(self, *args)
         self.fileobj = None

--- a/metalink/proxy.py
+++ b/metalink/proxy.py
@@ -94,16 +94,19 @@ def translate() -> Callable[[str], str]:
 
     locale_lang = locale.getdefaultlocale()[0]
     if locale_lang is None:
-        locale_lang = "en" # Fallback to "en" if no system locale is found
+        locale_lang = "en"  # Fallback to "en" if no system locale is found
 
     try:
         # Load translation
-        t = gettext.translation(domain=base, localedir=localedir, languages=[locale_lang], fallback=True)
+        t = gettext.translation(
+            domain=base, localedir=localedir, languages=[locale_lang], fallback=True
+        )
     except FileNotFoundError:
         # If the translation file doesn't exist, use a fallback
         t = gettext.NullTranslations()
 
     return t.gettext
+
 
 _ = translate()
 
@@ -149,11 +152,11 @@ def get_proxy_info():
     if "https_proxy" in os.environ and HTTPS_PROXY == "":
         HTTPS_PROXY = os.environ["https_proxy"]
 
-    if platform.system() == 'Windows':
+    if platform.system() == "Windows":
         # from IE in registry
         proxy_enable = get_key_value(
             r"Software\Microsoft\Windows\CurrentVersion\Internet Settings",
-            "ProxyEnable"
+            "ProxyEnable",
         )
         try:
             proxy_enable = bool(proxy_enable[-1])
@@ -165,17 +168,23 @@ def get_proxy_info():
                 "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
                 "ProxyServer",
             )
-            if not "=" in proxy_string:
+            if "=" not in proxy_string:
                 # if all use the same settings
                 for proxy in ("HTTP_PROXY", "FTP_PROXY", "HTTPS_PROXY"):
                     if getattr(sys.modules[__name__], proxy) == "":
-                        setattr(sys.modules[__name__], proxy, "http://" + str(proxy_string))
+                        setattr(
+                            sys.modules[__name__], proxy, "http://" + str(proxy_string)
+                        )
             else:
                 proxies = proxy_string.split(";")
                 for proxy in proxies:
                     name, value = proxy.split("=")
                     if getattr(sys.modules[__name__], name.upper() + "_PROXY") == "":
-                        setattr(sys.modules[__name__], name.upper() + "_PROXY", "http://" + value)
+                        setattr(
+                            sys.modules[__name__],
+                            name.upper() + "_PROXY",
+                            "http://" + value,
+                        )
     else:
         # Todo
         pass
@@ -381,7 +390,6 @@ class FTP(ftplib.FTP):
             ftplib.FTP.close(self)
 
 
-
 class HTTPConnection(http.client.HTTPConnection):
     def __init__(self, host, port=None, *args, **kwargs):
         super().__init__(host, port, *args, **kwargs)
@@ -390,7 +398,9 @@ class HTTPConnection(http.client.HTTPConnection):
             headers = {}
             proxy = urllib.parse.urlparse(HTTP_PROXY)
             if proxy.scheme not in ("", "http"):
-                raise ValueError(f"Transport {proxy.scheme} not supported for HTTP_PROXY")
+                raise ValueError(
+                    f"Transport {proxy.scheme} not supported for HTTP_PROXY"
+                )
 
             if proxy.username:
                 # Encode username and password for proxy authorization
@@ -414,7 +424,9 @@ class HTTPSConnection(http.client.HTTPSConnection):
             headers = {}
             proxy = urllib.parse.urlparse(HTTPS_PROXY)
             if proxy.scheme not in ("", "http"):
-                raise ValueError(f"Transport {proxy.scheme} not supported for HTTPS_PROXY")
+                raise ValueError(
+                    f"Transport {proxy.scheme} not supported for HTTPS_PROXY"
+                )
 
             if proxy.username:
                 # Encode username and password for proxy authorization

--- a/metalink/proxy.py
+++ b/metalink/proxy.py
@@ -62,6 +62,7 @@ import urllib
 import urllib.parse
 import urllib.request
 import winreg
+from typing import Callable
 
 unicode = str
 # Configure proxies (user and password optional)
@@ -72,7 +73,7 @@ HTTPS_PROXY = ""
 SOCKS_PROXY = ""
 
 
-def translate():
+def translate() -> Callable[[str], str]:
     """
     Setup translation path
     """
@@ -91,11 +92,17 @@ def translate():
         base = temp[-1]
         localedir = os.path.join("/".join(["%s" % k for k in temp[:-1]]), "locale")
 
-    # print base, localedir
     locale_lang = locale.getdefaultlocale()[0]
     if locale_lang is None:
-        locale_lang = "LC_ALL"
-    t = gettext.translation(base, localedir, [locale_lang], None, "en")
+        locale_lang = "en" # Fallback to "en" if no system locale is found
+
+    try:
+        # Load translation
+        t = gettext.translation(domain=base, localedir=localedir, languages=[locale_lang], fallback=True)
+    except FileNotFoundError:
+        # If the translation file doesn't exist, use a fallback
+        t = gettext.NullTranslations()
+
     return t.gettext
 
 _ = translate()


### PR DESCRIPTION
This PR restores proxy support for HTTP(S) under Python 3. (FTP still not supported)

### Changes:
##### Key Changes
- Updated proxy handling code to work with Python 3 in proxy.py.
##### Other Changes
- Replaced some non available function calls in download.py and refactoring of variable names.
- Fixed usage of (unused?) Translation.

### Fixes:
Resolves #34